### PR TITLE
Added single and double pass ComputeMeanAndCovariance functions, plus basic self-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Experiments with mean and covariance computation in PCL.
 
 1. **Clone this repository** 
 
-   Clone with submodules and pass the `--recursive` flag:
+   Clone with submodules and pass the `--recursive-submodules` flag:
 
        $ git clone https://github.com/taketwo/pcl-mean-and-covariance.git --recursive-submodules
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ Experiments with mean and covariance computation in PCL.
 
 2. **Configure with CMake**
     
-       $ cd <path to>/pcl-mean-and-covariance
-       $ cmake -C CMakeLists.txt -G "Unix Makefiles"
+       $ cd <path to>/pcl-mean-and-covariance/
+       $ mkdir build
+       $ cd build/
+       $ cmake ..
 
-   Note: CMake 3.5 or higher is required. Also note that the generator specified after the `-G` can be something other than Unix Makefiles, E.g. Ninja. 
+   Note: CMake 3.5 or higher is required. 
 
 3. **Install `datamash`** 
 
@@ -27,12 +29,14 @@ Experiments with mean and covariance computation in PCL.
 
 4. **Build and run benchmarks** 
 
-       $ cd ~/bench
+   From the `build` folder, run:
+
        $ make benchmarks
 
 5. **Build and run tests** 
 
-       $ cd ~/tests
+   From the `build` folder, run:
+
        $ make tests
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -6,18 +6,16 @@ Experiments with mean and covariance computation in PCL.
 
 1. **Clone this repository** 
 
-   Clone with submodules and pass the `--recursive-submodules` flag:
+   Clone with submodules and pass the `--recursive` flag:
 
        $ git clone https://github.com/taketwo/pcl-mean-and-covariance.git --recursive-submodules
 
 2. **Configure with CMake**
     
-       $ cd <path to>/pcl-mean-and-covariance/
-       $ mkdir build
-       $ cd build/
-       $ cmake ..
+       $ cd <path to>/pcl-mean-and-covariance
+       $ cmake -C CMakeLists.txt -G "Unix Makefiles"
 
-   Note: CMake 3.5 or higher is required. 
+   Note: CMake 3.5 or higher is required. Also note that the generator specified after the `-G` can be something other than Unix Makefiles, E.g. Ninja. 
 
 3. **Install `datamash`** 
 
@@ -29,14 +27,12 @@ Experiments with mean and covariance computation in PCL.
 
 4. **Build and run benchmarks** 
 
-   From the `build` folder, run:
-
+       $ cd ~/bench
        $ make benchmarks
 
 5. **Build and run tests** 
 
-   From the `build` folder, run:
-
+       $ cd ~/tests
        $ make tests
 
 ## Troubleshooting

--- a/src/mean_and_covariance.hpp
+++ b/src/mean_and_covariance.hpp
@@ -8,51 +8,51 @@ namespace pcl
 namespace experimental
 {
 
-//template <typename PointT, typename Scalar> inline unsigned int
-//computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-//                                     const std::vector<int> &indices,
-//                                     Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
-//                                     Eigen::Matrix<Scalar, 4, 1> &centroid)
-//{
-//  // create the buffer on the stack which is much faster than using cloud[indices[i]] and centroid as a buffer
-//  Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor> accu = Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor>::Zero ();
-//  size_t point_count;
-//  Eigen::Vector3f approx_centroid = cloud[indices[0]].getVector3fMap();
-//  point_count = indices.size ();
-//  for (std::vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)
-//  {
-//    const Eigen::Vector3f point = cloud[*iIt].getVector3fMap() - approx_centroid;
-//    accu [0] += point[0] * point[0];
-//    accu [1] += point[0] * point[1];
-//    accu [2] += point[0] * point[2];
-//    accu [3] += point[1] * point[1];
-//    accu [4] += point[1] * point[2];
-//    accu [5] += point[2] * point[2];
-//    accu [6] += point[0];
-//    accu [7] += point[1];
-//    accu [8] += point[2];
-//  }
+template <typename PointT, typename Scalar> inline unsigned int
+computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                                const std::vector<int> &indices,
+                                Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
+                                Eigen::Matrix<Scalar, 4, 1> &centroid)
+{
+  // create the buffer on the stack which is much faster than using cloud[indices[i]] and centroid as a buffer
+  Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor> accu = Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor>::Zero ();
+  size_t point_count;
+  Eigen::Vector3f approx_centroid = cloud[indices[0]].getVector3fMap();
+  point_count = indices.size ();
+  for (std::vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)
+  {
+    const Eigen::Vector3f point = cloud[*iIt].getVector3fMap() - approx_centroid;
+    accu [0] += point[0] * point[0];
+    accu [1] += point[0] * point[1];
+    accu [2] += point[0] * point[2];
+    accu [3] += point[1] * point[1];
+    accu [4] += point[1] * point[2];
+    accu [5] += point[2] * point[2];
+    accu [6] += point[0];
+    accu [7] += point[1];
+    accu [8] += point[2];
+  }
 
-//  accu /= static_cast<Scalar> (point_count);
-//  //Eigen::Vector3f vec = accu.tail<3> ();
-//  //centroid.head<3> () = vec;//= accu.tail<3> ();
-//  //centroid.head<3> () = accu.tail<3> ();    -- does not compile with Clang 3.0
-//  centroid[0] = accu[6] + approx_centroid[0];
-//  centroid[1] = accu[7] + approx_centroid[1];
-//  centroid[2] = accu[8] + approx_centroid[2];
-//  centroid[3] = 1;
-//  covariance_matrix.coeffRef (0) = accu [0] - accu [6] * accu [6];
-//  covariance_matrix.coeffRef (1) = accu [1] - accu [6] * accu [7];
-//  covariance_matrix.coeffRef (2) = accu [2] - accu [6] * accu [8];
-//  covariance_matrix.coeffRef (4) = accu [3] - accu [7] * accu [7];
-//  covariance_matrix.coeffRef (5) = accu [4] - accu [7] * accu [8];
-//  covariance_matrix.coeffRef (8) = accu [5] - accu [8] * accu [8];
-//  covariance_matrix.coeffRef (3) = covariance_matrix.coeff (1);
-//  covariance_matrix.coeffRef (6) = covariance_matrix.coeff (2);
-//  covariance_matrix.coeffRef (7) = covariance_matrix.coeff (5);
+  accu /= static_cast<Scalar> (point_count);
+  //Eigen::Vector3f vec = accu.tail<3> ();
+  //centroid.head<3> () = vec;//= accu.tail<3> ();
+  //centroid.head<3> () = accu.tail<3> ();    -- does not compile with Clang 3.0
+  centroid[0] = accu[6] + approx_centroid[0];
+  centroid[1] = accu[7] + approx_centroid[1];
+  centroid[2] = accu[8] + approx_centroid[2];
+  centroid[3] = 1;
+  covariance_matrix.coeffRef (0) = accu [0] - accu [6] * accu [6];
+  covariance_matrix.coeffRef (1) = accu [1] - accu [6] * accu [7];
+  covariance_matrix.coeffRef (2) = accu [2] - accu [6] * accu [8];
+  covariance_matrix.coeffRef (4) = accu [3] - accu [7] * accu [7];
+  covariance_matrix.coeffRef (5) = accu [4] - accu [7] * accu [8];
+  covariance_matrix.coeffRef (8) = accu [5] - accu [8] * accu [8];
+  covariance_matrix.coeffRef (3) = covariance_matrix.coeff (1);
+  covariance_matrix.coeffRef (6) = covariance_matrix.coeff (2);
+  covariance_matrix.coeffRef (7) = covariance_matrix.coeff (5);
 
-//  return (static_cast<unsigned int> (point_count));
-//}
+  return (static_cast<unsigned int> (point_count));
+}
 
 
 int add_two_numbers(int a, int b)

--- a/src/mean_and_covariance.hpp
+++ b/src/mean_and_covariance.hpp
@@ -36,30 +36,33 @@ computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   // create the buffer on the stack which is much faster than using cloud[indices[i]] and centroid as a buffer
   Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor> accu = Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor>::Zero ();
   size_t point_count;
-  Eigen::Vector3f approx_centroid = cloud[indices[0]].getVector3fMap();
   point_count = indices.size ();
+  Eigen::Vector3f approx_centroid = cloud[indices[0]].getVector3fMap();
+
+  // Accumulate a sum of the values we need (e.g. X*X) in 'accu'
   for (std::vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)
   {
+    // First subtract the centroid to center the point at the origin
     const Eigen::Vector3f point = cloud[*iIt].getVector3fMap() - approx_centroid;
-    accu [0] += point[0] * point[0];
-    accu [1] += point[0] * point[1];
-    accu [2] += point[0] * point[2];
-    accu [3] += point[1] * point[1];
-    accu [4] += point[1] * point[2];
-    accu [5] += point[2] * point[2];
-    accu [6] += point[0];
-    accu [7] += point[1];
-    accu [8] += point[2];
+    accu [0] += point[0] * point[0];    //  X*X
+    accu [1] += point[0] * point[1];    //  X*Y
+    accu [2] += point[0] * point[2];    //  X*Z
+    accu [3] += point[1] * point[1];    //  Y*Y
+    accu [4] += point[1] * point[2];    //  Y*Z
+    accu [5] += point[2] * point[2];    //  Z*Z
+    accu [6] += point[0];               //  X
+    accu [7] += point[1];               //  Y
+    accu [8] += point[2];               //  Z
   }
-
   accu /= static_cast<Scalar> (point_count);
-  //Eigen::Vector3f vec = accu.tail<3> ();
-  //centroid.head<3> () = vec;//= accu.tail<3> ();
-  //centroid.head<3> () = accu.tail<3> ();    -- does not compile with Clang 3.0
+
+  // Calculate the actual centroid (the 'mean' of the point cloud)
   centroid[0] = accu[6] + approx_centroid[0];
   centroid[1] = accu[7] + approx_centroid[1];
   centroid[2] = accu[8] + approx_centroid[2];
   centroid[3] = 1;
+
+  // Now calculate the covariance matrix
   covariance_matrix.coeffRef (0) = accu [0] - accu [6] * accu [6];
   covariance_matrix.coeffRef (1) = accu [1] - accu [6] * accu [7];
   covariance_matrix.coeffRef (2) = accu [2] - accu [6] * accu [8];

--- a/src/mean_and_covariance.hpp
+++ b/src/mean_and_covariance.hpp
@@ -31,13 +31,15 @@ template <typename PointT, typename Scalar> inline unsigned int
 computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
                                 const std::vector<int> &indices,
                                 Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
-                                Eigen::Matrix<Scalar, 4, 1> &centroid)
+                                Eigen::Matrix<Scalar, 4, 1> &centroid,
+                                bool demean)
 {
   // create the buffer on the stack which is much faster than using cloud[indices[i]] and centroid as a buffer
   Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor> accu = Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor>::Zero ();
   size_t point_count;
   point_count = indices.size ();
-  Eigen::Vector3f approx_centroid = cloud[indices[0]].getVector3fMap();
+  Eigen::Vector3f approx_centroid = Eigen::Vector3f::Zero();
+  if (demean) approx_centroid = cloud[indices[0]].getVector3fMap();
 
   // Accumulate a sum of the values we need (e.g. X*X) in 'accu'
   for (std::vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)
@@ -85,13 +87,15 @@ template <typename PointT, typename Scalar> inline unsigned int
 computeMeanAndCovarianceMatrixDoublePass (const pcl::PointCloud<PointT> &cloud,
                                           const std::vector<int> &indices,
                                           Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
-                                          Eigen::Matrix<Scalar, 4, 1> &centroid)
+                                          Eigen::Matrix<Scalar, 4, 1> &centroid,
+                                          bool demean)
 {
   // create the buffer on the stack which is much faster than using cloud[indices[i]] and centroid as a buffer
   Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor> accu = Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor>::Zero ();
   size_t point_count;
   point_count = cloud.size ();
-  Eigen::Vector3f approx_centroid = cloud[indices[0]].getVector3fMap();
+  Eigen::Vector3f approx_centroid = Eigen::Vector3f::Zero();
+  if (demean) approx_centroid = cloud[indices[0]].getVector3fMap();
 
   // For each point in the cloud
   for (std::vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)

--- a/src/mean_and_covariance.hpp
+++ b/src/mean_and_covariance.hpp
@@ -8,53 +8,60 @@ namespace pcl
 namespace experimental
 {
 
-template <typename PointT, typename Scalar> inline unsigned int
-computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                                     const std::vector<int> &indices,
-                                     Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
-                                     Eigen::Matrix<Scalar, 4, 1> &centroid)
+//template <typename PointT, typename Scalar> inline unsigned int
+//computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+//                                     const std::vector<int> &indices,
+//                                     Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
+//                                     Eigen::Matrix<Scalar, 4, 1> &centroid)
+//{
+//  // create the buffer on the stack which is much faster than using cloud[indices[i]] and centroid as a buffer
+//  Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor> accu = Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor>::Zero ();
+//  size_t point_count;
+//  Eigen::Vector3f approx_centroid = cloud[indices[0]].getVector3fMap();
+//  point_count = indices.size ();
+//  for (std::vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)
+//  {
+//    const Eigen::Vector3f point = cloud[*iIt].getVector3fMap() - approx_centroid;
+//    accu [0] += point[0] * point[0];
+//    accu [1] += point[0] * point[1];
+//    accu [2] += point[0] * point[2];
+//    accu [3] += point[1] * point[1];
+//    accu [4] += point[1] * point[2];
+//    accu [5] += point[2] * point[2];
+//    accu [6] += point[0];
+//    accu [7] += point[1];
+//    accu [8] += point[2];
+//  }
+
+//  accu /= static_cast<Scalar> (point_count);
+//  //Eigen::Vector3f vec = accu.tail<3> ();
+//  //centroid.head<3> () = vec;//= accu.tail<3> ();
+//  //centroid.head<3> () = accu.tail<3> ();    -- does not compile with Clang 3.0
+//  centroid[0] = accu[6] + approx_centroid[0];
+//  centroid[1] = accu[7] + approx_centroid[1];
+//  centroid[2] = accu[8] + approx_centroid[2];
+//  centroid[3] = 1;
+//  covariance_matrix.coeffRef (0) = accu [0] - accu [6] * accu [6];
+//  covariance_matrix.coeffRef (1) = accu [1] - accu [6] * accu [7];
+//  covariance_matrix.coeffRef (2) = accu [2] - accu [6] * accu [8];
+//  covariance_matrix.coeffRef (4) = accu [3] - accu [7] * accu [7];
+//  covariance_matrix.coeffRef (5) = accu [4] - accu [7] * accu [8];
+//  covariance_matrix.coeffRef (8) = accu [5] - accu [8] * accu [8];
+//  covariance_matrix.coeffRef (3) = covariance_matrix.coeff (1);
+//  covariance_matrix.coeffRef (6) = covariance_matrix.coeff (2);
+//  covariance_matrix.coeffRef (7) = covariance_matrix.coeff (5);
+
+//  return (static_cast<unsigned int> (point_count));
+//}
+
+
+int add_two_numbers(int a, int b)
 {
-  // create the buffer on the stack which is much faster than using cloud[indices[i]] and centroid as a buffer
-  Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor> accu = Eigen::Matrix<Scalar, 1, 9, Eigen::RowMajor>::Zero ();
-  size_t point_count;
-  Eigen::Vector3f approx_centroid = cloud[indices[0]].getVector3fMap();
-  point_count = indices.size ();
-  for (std::vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)
-  {
-    const Eigen::Vector3f point = cloud[*iIt].getVector3fMap() - approx_centroid;
-    accu [0] += point[0] * point[0];
-    accu [1] += point[0] * point[1];
-    accu [2] += point[0] * point[2];
-    accu [3] += point[1] * point[1];
-    accu [4] += point[1] * point[2];
-    accu [5] += point[2] * point[2];
-    accu [6] += point[0];
-    accu [7] += point[1];
-    accu [8] += point[2];
-  }
-
-  accu /= static_cast<Scalar> (point_count);
-  //Eigen::Vector3f vec = accu.tail<3> ();
-  //centroid.head<3> () = vec;//= accu.tail<3> ();
-  //centroid.head<3> () = accu.tail<3> ();    -- does not compile with Clang 3.0
-  centroid[0] = accu[6] + approx_centroid[0];
-  centroid[1] = accu[7] + approx_centroid[1];
-  centroid[2] = accu[8] + approx_centroid[2];
-  centroid[3] = 1;
-  covariance_matrix.coeffRef (0) = accu [0] - accu [6] * accu [6];
-  covariance_matrix.coeffRef (1) = accu [1] - accu [6] * accu [7];
-  covariance_matrix.coeffRef (2) = accu [2] - accu [6] * accu [8];
-  covariance_matrix.coeffRef (4) = accu [3] - accu [7] * accu [7];
-  covariance_matrix.coeffRef (5) = accu [4] - accu [7] * accu [8];
-  covariance_matrix.coeffRef (8) = accu [5] - accu [8] * accu [8];
-  covariance_matrix.coeffRef (3) = covariance_matrix.coeff (1);
-  covariance_matrix.coeffRef (6) = covariance_matrix.coeff (2);
-  covariance_matrix.coeffRef (7) = covariance_matrix.coeff (5);
-
-  return (static_cast<unsigned int> (point_count));
+  return (a+b);
 }
 
-}
 
-}
+} // namespace experimental
+
+} // namespace pcl
 

--- a/src/mean_and_covariance.hpp
+++ b/src/mean_and_covariance.hpp
@@ -8,6 +8,25 @@ namespace pcl
 namespace experimental
 {
 
+/* Mathematics for a single pass covariance calculation from a set of XYZ points.
+ * If the covariance matrix is structured like so:
+ *
+ *    | 0 1 2 |
+ *    | 3 4 5 |
+ *    | 6 7 8 |
+ *
+ * Then:
+ *
+ *    0 = mean(X*X) - sum(X) * sum(X)
+ *    1 = mean(X*Y) - sum(X) * sum(Y)
+ *    2 = mean(X*Z) - sum(X) * sum(Z)
+ *    3 = 1 = mean(X*Y) - sum(X) * sum(Y)
+ *    4 = mean(Y*Y) - sum(Y) * sum(Y)
+ *    5 = mean(Y*Z) - sum(Y) * sum(Z)
+ *    6 = 2 = mean(X*Z) - sum(X) * sum(Z)
+ *    7 = 5 = mean(Y*Z) - sum(Y) * sum(Z)
+ *    8 = mean(Z*Z) - sum(Z) * sum(Z)
+ */
 template <typename PointT, typename Scalar> inline unsigned int
 computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
                                 const std::vector<int> &indices,

--- a/src/mean_and_covariance.hpp
+++ b/src/mean_and_covariance.hpp
@@ -15,7 +15,7 @@ namespace experimental
  *    | 3 4 5 |
  *    | 6 7 8 |
  *
- * Then:
+ * Where:
  *
  *    0 = mean(X*X) - sum(X) * sum(X)
  *    1 = mean(X*Y) - sum(X) * sum(Y)
@@ -77,9 +77,9 @@ computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
 }
 
 
+
 /* This is based on the double-pass calculation suggested here:
  *    https://github.com/PointCloudLibrary/pcl/pull/1407
- *
  */
 template <typename PointT, typename Scalar> inline unsigned int
 computeMeanAndCovarianceMatrixDoublePass (const pcl::PointCloud<PointT> &cloud,
@@ -133,11 +133,6 @@ computeMeanAndCovarianceMatrixDoublePass (const pcl::PointCloud<PointT> &cloud,
   covariance_matrix.coeffRef (7) = covariance_matrix.coeff (5);
 
   return (static_cast<unsigned int> (point_count));
-}
-
-int add_two_numbers(int a, int b)
-{
-  return (a+b);
 }
 
 

--- a/test/test_mean_and_covariance.cpp
+++ b/test/test_mean_and_covariance.cpp
@@ -1,4 +1,6 @@
 #include <gtest/gtest.h>
+#include <pcl/point_types.h>              // PointXYZ, PointXYZRGB etc
+#include <pcl/point_cloud.h>
 #include <mean_and_covariance.hpp>
 
 TEST(TestCaseName, TestCase)

--- a/test/test_mean_and_covariance.cpp
+++ b/test/test_mean_and_covariance.cpp
@@ -1,4 +1,14 @@
 #include <gtest/gtest.h>
+#include <mean_and_covariance.hpp>
+
+TEST(TestCaseName, TestCase)
+{
+  int a = 1;
+  int b = 2;
+  int c = pcl::experimental::add_two_numbers(a,b);
+  EXPECT_EQ(c, 3);
+}
+
 
 int main (int argc, char** argv)
 {

--- a/test/test_mean_and_covariance.cpp
+++ b/test/test_mean_and_covariance.cpp
@@ -27,12 +27,12 @@ TEST(MeanAndCovariance, SelfTest)
                                 0.0, 0.0, 0.0;
 
   // Input to our covariance matrix functions
-  computeMeanAndCovarianceMatrix(c, indices, covariance_matrix_sp_f, centroid_sp_f);
-  computeMeanAndCovarianceMatrix(c, indices, covariance_matrix_sp_d, centroid_sp_d);
+  computeMeanAndCovarianceMatrix(c, indices, covariance_matrix_sp_f, centroid_sp_f, 1);
+  computeMeanAndCovarianceMatrix(c, indices, covariance_matrix_sp_d, centroid_sp_d, 1);
   computeMeanAndCovarianceMatrixDoublePass(c, indices, covariance_matrix_dp_f,
-                                           centroid_dp_f);
+                                           centroid_dp_f, 1);
   computeMeanAndCovarianceMatrixDoublePass(c, indices, covariance_matrix_dp_d,
-                                           centroid_dp_d);
+                                           centroid_dp_d, 1);
 
   // Check all centroids
   for (int i = 0; i < 4; i++)

--- a/test/test_mean_and_covariance.cpp
+++ b/test/test_mean_and_covariance.cpp
@@ -1,14 +1,56 @@
 #include <gtest/gtest.h>
 #include <pcl/point_types.h>              // PointXYZ, PointXYZRGB etc
 #include <pcl/point_cloud.h>
-#include <mean_and_covariance.hpp>
+#include <mean_and_covariance.hpp>        // Includes all the functions we want to test
 
-TEST(TestCaseName, TestCase)
+using namespace pcl;
+using namespace pcl::experimental;
+
+
+TEST(MeanAndCovariance, SelfTest)
 {
-  int a = 1;
-  int b = 2;
-  int c = pcl::experimental::add_two_numbers(a,b);
-  EXPECT_EQ(c, 3);
+  // Create a super-basic cloud
+  PointCloud<PointXYZ> c;
+  PointXYZ p1 (1.0f, 1.0f, 0.0f), p2 (1.0f, -1.0f, 0.0f),
+           p3 (-1.0f, -1.0f, 0.0f), p4 (-1.0f, 1.0f, 0.0f);
+  c.push_back(p1); c.push_back(p2); c.push_back(p3); c.push_back(p4);
+
+  // Create the rest of our input parameters and our expected results
+  const std::vector<int> indices = {0,1,2,3};
+  Eigen::Vector4f centroid_sp, centroid_dp, centroid_expected;
+  Eigen::Matrix3f covariance_matrix_sp, covariance_matrix_dp,
+                  covariance_matrix_expected;
+  centroid_expected = {0,0,0,1};
+  covariance_matrix_expected << 1.0, 0.0, 0.0,
+                                0.0, 1.0, 0.0,
+                                0.0, 0.0, 0.0;
+
+  // Input to our covariance matrix functions
+  computeMeanAndCovarianceMatrix(c, indices, covariance_matrix_sp, centroid_sp);
+  computeMeanAndCovarianceMatrixDoublePass(c, indices, covariance_matrix_dp,
+                                           centroid_dp);
+
+  // Check calculations vs expected values
+  EXPECT_TRUE(centroid_sp.isApprox(centroid_expected));
+  EXPECT_TRUE(centroid_dp.isApprox(centroid_expected));
+  EXPECT_TRUE(covariance_matrix_sp.isApprox(covariance_matrix_expected));
+  EXPECT_TRUE(covariance_matrix_dp.isApprox(covariance_matrix_expected));
+
+
+//  // In general, three options for comparing calculated with expected values
+
+//  // Method 1 (explicit)
+//  EXPECT_EQ(centroid_sp[0], 0.0); EXPECT_EQ(centroid_sp[1], 0.0);
+//  EXPECT_EQ(centroid_sp[2], 0.0); EXPECT_EQ(centroid_sp[3], 1.0);
+
+//  // Method 2 (iterate)
+//  for (int i = 0; i < 4; i++)
+//  {
+//    EXPECT_EQ(centroid_expected[i], centroid_sp[i]);
+//  }
+
+//  // Method 3 (Eigen approx)
+//  EXPECT_TRUE(centroid_sp.isApprox(centroid_expected));
 }
 
 

--- a/test/test_mean_and_covariance.cpp
+++ b/test/test_mean_and_covariance.cpp
@@ -30,27 +30,26 @@ TEST(MeanAndCovariance, SelfTest)
   computeMeanAndCovarianceMatrixDoublePass(c, indices, covariance_matrix_dp,
                                            centroid_dp);
 
-  // Check calculations vs expected values
-  EXPECT_TRUE(centroid_sp.isApprox(centroid_expected));
-  EXPECT_TRUE(centroid_dp.isApprox(centroid_expected));
-  EXPECT_TRUE(covariance_matrix_sp.isApprox(covariance_matrix_expected));
-  EXPECT_TRUE(covariance_matrix_dp.isApprox(covariance_matrix_expected));
+  // Check centroid
+  for (int i = 0; i < 4; i++)
+  {
+    EXPECT_EQ(centroid_expected[i], centroid_sp[i]) \
+              << "Single-pass centroid differs at index " << i;
+    EXPECT_EQ(centroid_expected[i], centroid_sp[i]) \
+              << "Double-pass centroid differs at index " << i;
+  }
 
-
-//  // In general, three options for comparing calculated with expected values
-
-//  // Method 1 (explicit)
-//  EXPECT_EQ(centroid_sp[0], 0.0); EXPECT_EQ(centroid_sp[1], 0.0);
-//  EXPECT_EQ(centroid_sp[2], 0.0); EXPECT_EQ(centroid_sp[3], 1.0);
-
-//  // Method 2 (iterate)
-//  for (int i = 0; i < 4; i++)
-//  {
-//    EXPECT_EQ(centroid_expected[i], centroid_sp[i]);
-//  }
-
-//  // Method 3 (Eigen approx)
-//  EXPECT_TRUE(centroid_sp.isApprox(centroid_expected));
+  // Check covariance-matrix
+  for (int col = 0; col < 3; col++)
+  {
+    for (int row = 0; row < 3; row++)
+    {
+      EXPECT_EQ(covariance_matrix_sp(row, col), covariance_matrix_expected(row, col)) \
+                << "Single-pass covariance matrix differs at row " << row << ", col " << col;
+      EXPECT_EQ(covariance_matrix_dp(row, col), covariance_matrix_expected(row, col)) \
+                << "Double-pass covariance matrix differs at row " << row << ", col " << col;
+    }
+  }
 }
 
 

--- a/test/test_mean_and_covariance.cpp
+++ b/test/test_mean_and_covariance.cpp
@@ -17,37 +17,53 @@ TEST(MeanAndCovariance, SelfTest)
 
   // Create the rest of our input parameters and our expected results
   const std::vector<int> indices = {0,1,2,3};
-  Eigen::Vector4f centroid_sp, centroid_dp, centroid_expected;
-  Eigen::Matrix3f covariance_matrix_sp, covariance_matrix_dp,
-                  covariance_matrix_expected;
+  Eigen::Vector4f centroid_sp_f, centroid_dp_f, centroid_expected;
+  Eigen::Vector4d centroid_sp_d, centroid_dp_d;
+  Eigen::Matrix3f covariance_matrix_sp_f, covariance_matrix_dp_f, covariance_matrix_expected;
+  Eigen::Matrix3d covariance_matrix_sp_d, covariance_matrix_dp_d;
   centroid_expected = {0,0,0,1};
   covariance_matrix_expected << 1.0, 0.0, 0.0,
                                 0.0, 1.0, 0.0,
                                 0.0, 0.0, 0.0;
 
   // Input to our covariance matrix functions
-  computeMeanAndCovarianceMatrix(c, indices, covariance_matrix_sp, centroid_sp);
-  computeMeanAndCovarianceMatrixDoublePass(c, indices, covariance_matrix_dp,
-                                           centroid_dp);
+  computeMeanAndCovarianceMatrix(c, indices, covariance_matrix_sp_f, centroid_sp_f);
+  computeMeanAndCovarianceMatrix(c, indices, covariance_matrix_sp_d, centroid_sp_d);
+  computeMeanAndCovarianceMatrixDoublePass(c, indices, covariance_matrix_dp_f,
+                                           centroid_dp_f);
+  computeMeanAndCovarianceMatrixDoublePass(c, indices, covariance_matrix_dp_d,
+                                           centroid_dp_d);
 
-  // Check centroid
+  // Check all centroids
   for (int i = 0; i < 4; i++)
   {
-    EXPECT_EQ(centroid_expected[i], centroid_sp[i]) \
-              << "Single-pass centroid differs at index " << i;
-    EXPECT_EQ(centroid_expected[i], centroid_sp[i]) \
-              << "Double-pass centroid differs at index " << i;
+    EXPECT_EQ(centroid_expected[i], centroid_sp_f[i]) \
+              << "Single-pass, single precision centroid differs at index " << i;
+    EXPECT_EQ(centroid_expected[i], centroid_dp_f[i]) \
+              << "Double-pass, single precision centroid differs at index " << i;
+    EXPECT_EQ(centroid_expected[i], centroid_sp_d[i]) \
+              << "Single-pass, double precision centroid differs at index " << i;
+    EXPECT_EQ(centroid_expected[i], centroid_dp_d[i]) \
+              << "Double-pass, double precision centroid differs at index " << i;
   }
 
-  // Check covariance-matrix
+  // Check all covariance-matrices
   for (int col = 0; col < 3; col++)
   {
     for (int row = 0; row < 3; row++)
     {
-      EXPECT_EQ(covariance_matrix_sp(row, col), covariance_matrix_expected(row, col)) \
-                << "Single-pass covariance matrix differs at row " << row << ", col " << col;
-      EXPECT_EQ(covariance_matrix_dp(row, col), covariance_matrix_expected(row, col)) \
-                << "Double-pass covariance matrix differs at row " << row << ", col " << col;
+      EXPECT_EQ(covariance_matrix_sp_f(row, col), covariance_matrix_expected(row, col)) \
+                << "Single-pass, single precision covariance matrix differs at row "
+                << row << ", col " << col;
+      EXPECT_EQ(covariance_matrix_dp_f(row, col), covariance_matrix_expected(row, col)) \
+                << "Double-pass, single precision covariance matrix differs at row "
+                << row << ", col " << col;
+      EXPECT_EQ(covariance_matrix_sp_d(row, col), covariance_matrix_expected(row, col)) \
+                << "Single-pass, double precision covariance matrix differs at row "
+                << row << ", col " << col;
+      EXPECT_EQ(covariance_matrix_dp_d(row, col), covariance_matrix_expected(row, col)) \
+                << "Double-pass, double precision covariance matrix differs at row "
+                << row << ", col " << col;
     }
   }
 }


### PR DESCRIPTION
So how do these functions look for single and double pass ComputeMeanAndCovariance? I can add a toggle later so the user can de-meaning on or off, but currently both functions de-mean by default. 

I've also added a very basic self-test for the functions to confirm they work. In regards to how we actually test the results there are three options, which I've illustrated with the centroid:

``` c++
// Method 1 (explicit but space inefficient) 
EXPECT_EQ(centroid_sp[0], 0.0); EXPECT_EQ(centroid_sp[1], 0.0);
EXPECT_EQ(centroid_sp[2], 0.0); EXPECT_EQ(centroid_sp[3], 1.0);

// Method 2 (iterative so scales well but doesn't show which element failed)
for (int i = 0; i < 4; i++)
{
  EXPECT_EQ(centroid_expected[i], centroid_sp[i]);
}

// Method 3 (Eigen approx, most space efficient but least informative)
EXPECT_TRUE(centroid_sp.isApprox(centroid_expected));
```
So do these functions look ok? And which calculated vs expected comparison method do we prefer?